### PR TITLE
Adding support for authorization code flow for OIDC login

### DIFF
--- a/Goobi/src/main/java/de/sub/goobi/config/ConfigurationHelper.java
+++ b/Goobi/src/main/java/de/sub/goobi/config/ConfigurationHelper.java
@@ -657,11 +657,23 @@ public class ConfigurationHelper implements Serializable {
     public String getOIDCAuthEndpoint() {
         return getLocalString("OIDCAuthEndpoint", "");
     }
-
+    
+    public String getOIDCFlowType() {
+    	return getLocalString("OIDCFlowType", "");
+    }
+    
     public String getOIDCLogoutEndpoint() {
         return getLocalString("OIDCLogoutEndpoint", "");
     }
-
+    
+    public String getOIDCTokenEndpoint() {
+    	return getLocalString("OIDCTokenEndpoint", "");
+    }
+    
+    public String getOIDCHostName() {
+    	return getLocalString("OIDCHostName", "");
+    }
+    
     public String getOIDCIssuer() {
         return getLocalString("OIDCIssuer", "");
     }
@@ -672,6 +684,10 @@ public class ConfigurationHelper implements Serializable {
 
     public String getOIDCClientID() {
         return getLocalString("OIDCClientID", "");
+    }
+    
+    public String getOIDCClientSecret() {
+        return getLocalString("OIDCClientSecret", "");
     }
 
     public String getOIDCIdClaim() {

--- a/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
+++ b/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
@@ -460,10 +460,10 @@ public class LoginBean implements Serializable {
         
         String flowType = config.getOIDCFlowType();
         
-        if (flowType == "ImplicitFlow") {
+        if (flowType.equals("ImplicitFlow")) {
         	openIDIFLogin();        	
         }
-        if (flowType == "AuthorizationCodeFlow") {
+        else if (flowType.equals("AuthorizationCodeFlow")) {
         	openIDACFLogin();        	
         }
         else { // Default case, when FlowType is not set in config file.

--- a/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
+++ b/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
@@ -457,27 +457,17 @@ public class LoginBean implements Serializable {
     public void openIDLogin() {
         ConfigurationHelper config = ConfigurationHelper.getInstance();
         ExternalContext ec = FacesContextHelper.getCurrentFacesContext().getExternalContext();
-        byte[] secureBytes = new byte[64];
-        new SecureRandomNumberGenerator().getSecureRandom().nextBytes(secureBytes);
-        String nonce = Base64.getUrlEncoder().encodeToString(secureBytes);
-        HttpSession session = (HttpSession) ec.getSession(false);
-        session.setAttribute("openIDNonce", nonce);
-        String applicationPath = ec.getApplicationContextPath();
-        HttpServletRequest hreq = (HttpServletRequest) ec.getRequest();
-        try {
-            URIBuilder builder = new URIBuilder(config.getOIDCAuthEndpoint());
-            builder.addParameter("client_id", config.getOIDCClientID());
-            builder.addParameter("response_type", "id_token");
-            builder.addParameter("redirect_uri",
-                    hreq.getScheme() + "://" + hreq.getServerName() + ":" + hreq.getServerPort() + applicationPath + "/api/login/openid");
-            builder.addParameter("response_mode", "form_post");
-            builder.addParameter("scope", "openid");
-            builder.addParameter("nonce", nonce);
-
-            ec.redirect(builder.build().toString());
-        } catch (URISyntaxException | IOException e) {
-            // TODO Auto-generated catch block
-            log.error(e);
+        
+        String flowType = config.getOIDCFlowType();
+        
+        if (flowType == "ImplicitFlow") {
+        	openIDIFLogin();        	
+        }
+        if (flowType == "AuthorizationCodeFlow") {
+        	openIDACFLogin();        	
+        }
+        else { // Default case, when FlowType is not set in config file.
+        	openIDIFLogin();        	
         }
     }
 

--- a/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
+++ b/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
@@ -417,6 +417,43 @@ public class LoginBean implements Serializable {
     	
     }
     
+    public void openIDACFLogin() {
+    	ConfigurationHelper config = ConfigurationHelper.getInstance();
+        ExternalContext ec = FacesContextHelper.getCurrentFacesContext().getExternalContext();
+        HttpSession session = (HttpSession) ec.getSession(false);
+        
+        byte[] secureBytes1 = new byte[64];
+    	new SecureRandomNumberGenerator().getSecureRandom().nextBytes(secureBytes1);
+    	String nonce = Base64.getUrlEncoder().encodeToString(secureBytes1);
+    	session.setAttribute("openIDNonce", nonce);
+    	
+    	byte[] secureBytes2 = new byte[64];
+    	new SecureRandomNumberGenerator().getSecureRandom().nextBytes(secureBytes2);
+    	String state = Base64.getUrlEncoder().encodeToString(secureBytes2);
+    	session.setAttribute("openIDState", state);
+    	
+    	String applicationPath = ec.getApplicationContextPath();
+    	HttpServletRequest hreq = (HttpServletRequest) ec.getRequest();
+        
+    	try {
+    		URIBuilder builder = new URIBuilder(config.getOIDCAuthEndpoint());
+    		builder.addParameter("client_id", config.getOIDCClientID());
+    		builder.addParameter("response_type", "code");
+    		builder.addParameter("redirect_uri",
+    				hreq.getScheme() + "://" + hreq.getServerName() + ":" + hreq.getServerPort() + applicationPath + "/api/login/openid/authorizationcodeflow");
+    		builder.addParameter("response_mode", "form_post");
+    		builder.addParameter("scope", "openid");
+    		builder.addParameter("nonce", nonce);
+    		builder.addParameter("state", state);
+    		
+    		ec.redirect(builder.build().toString());
+    	} catch (URISyntaxException | IOException e) {
+    		// TODO Auto-generated catch block
+    		log.error(e);
+    	}
+    	
+    }
+    
     public void openIDLogin() {
         ConfigurationHelper config = ConfigurationHelper.getInstance();
         ExternalContext ec = FacesContextHelper.getCurrentFacesContext().getExternalContext();

--- a/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
+++ b/Goobi/src/main/java/org/goobi/managedbeans/LoginBean.java
@@ -388,6 +388,35 @@ public class LoginBean implements Serializable {
         ec.redirect(Helper.getBaseUrl() + "/api/login/header");
     }
 
+    public void openIDIFLogin() {
+    	ConfigurationHelper config = ConfigurationHelper.getInstance();
+        ExternalContext ec = FacesContextHelper.getCurrentFacesContext().getExternalContext();
+        
+    	byte[] secureBytes = new byte[64];
+    	new SecureRandomNumberGenerator().getSecureRandom().nextBytes(secureBytes);
+    	String nonce = Base64.getUrlEncoder().encodeToString(secureBytes);
+    	HttpSession session = (HttpSession) ec.getSession(false);
+    	session.setAttribute("openIDNonce", nonce);
+    	String applicationPath = ec.getApplicationContextPath();
+    	HttpServletRequest hreq = (HttpServletRequest) ec.getRequest();
+    	try {
+    		URIBuilder builder = new URIBuilder(config.getOIDCAuthEndpoint());
+    		builder.addParameter("client_id", config.getOIDCClientID());
+    		builder.addParameter("response_type", "id_token");
+    		builder.addParameter("redirect_uri",
+    				hreq.getScheme() + "://" + hreq.getServerName() + ":" + hreq.getServerPort() + applicationPath + "/api/login/openid/implicitflow");
+    		builder.addParameter("response_mode", "form_post");
+    		builder.addParameter("scope", "openid");
+    		builder.addParameter("nonce", nonce);
+    		
+    		ec.redirect(builder.build().toString());
+    	} catch (URISyntaxException | IOException e) {
+    		// TODO Auto-generated catch block
+    		log.error(e);
+    	}
+    	
+    }
+    
     public void openIDLogin() {
         ConfigurationHelper config = ConfigurationHelper.getInstance();
         ExternalContext ec = FacesContextHelper.getCurrentFacesContext().getExternalContext();

--- a/Goobi/src/test/java/de/sub/goobi/config/ConfigurationHelperTest.java
+++ b/Goobi/src/test/java/de/sub/goobi/config/ConfigurationHelperTest.java
@@ -465,6 +465,11 @@ public class ConfigurationHelperTest extends AbstractTest {
     }
 
     @Test
+    public void testOIDCFlowType() {
+        assertEquals("", ConfigurationHelper.getInstance().getOIDCFlowType());
+    }
+    
+    @Test
     public void testGetOIDCAuthEndpoint() {
         assertEquals("", ConfigurationHelper.getInstance().getOIDCAuthEndpoint());
     }
@@ -473,7 +478,17 @@ public class ConfigurationHelperTest extends AbstractTest {
     public void testGetOIDCLogoutEndpoint() {
         assertEquals("", ConfigurationHelper.getInstance().getOIDCLogoutEndpoint());
     }
+    
+    @Test
+    public void testOIDCTokenEndpoint() {
+        assertEquals("", ConfigurationHelper.getInstance().getOIDCTokenEndpoint());
+    }
 
+    @Test
+    public void testOIDCHostName() {
+        assertEquals("", ConfigurationHelper.getInstance().getOIDCHostName());
+    }
+    
     @Test
     public void testGetOIDCIssuer() {
         assertEquals("", ConfigurationHelper.getInstance().getOIDCIssuer());
@@ -487,6 +502,11 @@ public class ConfigurationHelperTest extends AbstractTest {
     @Test
     public void testGetOIDCClientID() {
         assertEquals("", ConfigurationHelper.getInstance().getOIDCClientID());
+    }
+    
+    @Test
+    public void testGetOIDCClientSecret() {
+        assertEquals("", ConfigurationHelper.getInstance().getOIDCClientSecret());
     }
 
     @Test


### PR DESCRIPTION
## Motivation for suggesting new feature.
When configuring Open ID connect login for our instance of Goobi workflow, I noticed that Goobi Workflow only supports implicit flow. Our choice of OpenID Provider (OP) does not support this type of flow. In this pull request I have added support for authorization code flow in addition to implicit flow.
In addition, I thought this new feature/alteration could potentially be of use to others as well.

## Detailed description of changes made.
I made changes in 4 different files listed below:
### LoginBean.java
* Altered the openIDLogin method to call either openIDIFLogin or openIDACFLogin methods based on the flow type set in the goobi_config.properties file. Previously the OIDC login process was initiated by creating an authorization request for implicit flow.
* Moved the code responsible for initiating an OIDC login process with implicit flow into method openIDIFLogin.
* Created a new method for initiating an OIDC login process with authorization code flow. The authorization request is different from implicit flow by having an additional parameter called state. Also, the response_type parameter is altered to "code" instead of "id_token".

### Login.java
* Moved the code associated with endpoint /openid to /openid/implicitflow
* Created a new endpoint /openid/authorizationcodeflow for OIDC login process with authorization code flow. The logic is based on the previous implementation for implicit flow, but one crucial difference is made. The response from the OP does not immediately contain the id_token used for authentication, an additional step in the process is added. In this step the OP provides a state which is included in the initial request. This must be confirmed before sending an token request. The token request must include parameters Client ID, Client Secret, alongside the returned authorization code. These are then confirmed by the OP, before returning the id_token. The rest of the process is identical to other flow.

### ConfigurationHelper.java
* Added new getter methods for parameters used in OIDC authorization code flow.
*  getOIDCFlowType - Will return the flow type specified in goobi_config.properties. Either "ImplicitFlow" or "AuthorizationCodeFlow". If this is not configured the default choice would be "ImplicitFlow".
*  getOIDCTokenEndpoint - Will return the endpoint to which the token request is sent to. TokenEndpoint is specified in goobi_config.properties.
* getOIDCHostName - Will return the hostname of the OP. This must be included in the header of the token request. HostName is specified in goobi_config.properties
* get OIDCClientSecret - Will return the client secret specified in goobi_config.properties. Note this should be kept a secret and care must be taken if goobi_config.properties file is publicly available.

### ConfigurationHelperTest.java
* Added test for the newly defined getter methods.

## Other changes necessary for a working configuration.
* These following parameters must be defined in goobi_config.properties:
   - OIDCFlowType : AuthorizationCodeFlow
   - OIDCTokenEndpoint : https://exampleprovider.com/oauth/token
   - OIDCHostName : exampleprovider.com
   - OIDCClientSecret : insert_client_secret_here

* The following endpoints must also be included in goobi_rest.xml.:
```xml
    <endpoint path="/login/openid/authorizationcodeflow">
        <method name="post">
            <allow />
        </method>
    </endpoint>
    <endpoint path="/login/openid/implicitflow">
        <method name="post">
            <allow />
        </method>
    </endpoint>
```

## Notes
I tested the newly implemented flow with Feide Authentication Server (Identity service for Norwegian Educational Sector). This should follow a general authorization flow and hopefully other OP are compatible.
I tested the implicit flow with Googles Identity Platform, to make sure that the original code still was working.

Thank you for reviewing this and I hope the suggested changes are accepted. If not, I am happy to discuss it or if there are other ways to implement the suggested changes.

