### PR TITLE
fix path for mariadb data dir for persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
         target: /docker-entrypoint-initdb.d/goobi_blank.sql
       - type: volume
         source: goobi_dbdata
-        target: /var/lib/mysqldata
+        target: /var/lib/mysql/data
 
 
 volumes:


### PR DESCRIPTION
I think there is a typo in volume path, *someone* may end up without persistence while using the example.

https://hub.docker.com/_/mariadb

The path could also be moved up one level 

from:
https://hub.docker.com/_/mariadb

> The -v /my/own/datadir:/var/lib/mysql:Z part of the command mounts the /my/own/datadir directory from the underlying host system as /var/lib/mysql inside the container, where MariaDB by default will write its data files.

